### PR TITLE
Add JWT authentication, manual UI, and forecast monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,23 @@ Importar `postman/Reserva-Predictor.postman_collection.json` y seguir el flujo:
 5. Entrenar predictor (`POST /api/forecast/train`).
 6. Solicitar pronostico (`POST /api/forecast`).
 
+## Consolas web rápidas
+
+- `/manual` (solo usuarios ADMIN): panel HTML para alta y actualización manual de salas, recursos móviles y reservas.
+- `/monitor/forecast`: tablero de las últimas ejecuciones del predictor con métricas y horizonte proyectado.
+
 ## Datos de ejemplo
 
 - `java-backend/src/main/resources/data.sql`: seed inicial para H2.
 - `py-forecast/data/sample_series.json`: serie sintetica con tendencia + estacionalidad semanal.
+
+### Usuarios precargados (H2)
+
+| Email | Rol | Contraseña |
+| --- | --- | --- |
+| `maria.lopez@organizacion.com` | ADMIN | `AdminSecure1!` |
+| `ana.perez@organizacion.com` | STAFF | `AnaSecure1!` |
+| `juan.gomez@organizacion.com` | STAFF | `JuanSecure1!` |
 
 ## Documentacion
 

--- a/docs/endpoints.md
+++ b/docs/endpoints.md
@@ -4,6 +4,8 @@
 
 | Metodo | Camino | Descripcion | Request | Response |
 | --- | --- | --- | --- | --- |
+| POST | `/api/auth/register` | Alta de usuario (rol requerido: ADMIN) | `RegisterRequest` | `201` `AuthResponse` |
+| POST | `/api/auth/login` | Autenticación JWT | `AuthRequest` | `200` `AuthResponse` |
 | GET | `/api/persons` | Listar personas | - | `200` lista `PersonResponse` |
 | POST | `/api/persons` | Crear persona | `PersonRequest` | `201` `PersonResponse` |
 | PUT | `/api/persons/{id}` | Actualizar | `PersonRequest` | `200` `PersonResponse` |
@@ -18,6 +20,7 @@
 | GET | `/api/reservations/history` | Historial para predictor | Query `resourceType`, `resourceId`, `startDate?`, `endDate?` | `200` `HistoryResponse` |
 | POST | `/api/forecast/train` | Exporta historia y solicita entrenamiento | `TrainRequest` | `202` `TrainResponse` |
 | POST | `/api/forecast` | Pide pronostico | `ForecastRequest` | `200` `ForecastResponse` |
+| GET | `/api/forecast/monitor` | Últimas ejecuciones de pronóstico | - | `200` lista `ForecastSnapshotResponse` |
 
 ### Ejemplos
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,24 @@
+# Roadmap para funcionalidades solicitadas
+
+## 1. Registro y autenticación de usuarios por roles
+- Integrar un proveedor de identidad (Keycloak o Spring Authorization Server) siguiendo la sugerencia de la arquitectura para proteger `/api/**` con JWT y roles por recurso.
+- Extender el modelo de datos en `java-backend` agregando entidades `User`, `Role` y tablas relacionales, externalizando la base a Postgres para persistencia duradera.
+- Implementar endpoints de registro y administración de roles, complementados con un flujo de autenticación basado en OAuth2/OpenID Connect.
+- Actualizar filtros y controladores existentes para validar tokens, aplicar `@PreAuthorize` y restringir operaciones sensibles (por ejemplo, creación de reservas) según el rol.
+
+## 2. Ingreso y actualización de datos (manual y vía API)
+- Mantener los endpoints REST existentes para carga automatizada desde integraciones externas (`/api/persons`, `/api/rooms`, `/api/items`, `/api/reservations`).
+- Incorporar un frontend ligero (por ejemplo, React o Vue) como cliente web que consuma dichos endpoints y brinde formularios para alta/edición manual, tal como propone la documentación de arquitectura.
+- Asegurar validaciones consistentes entre frontend y backend, reutilizando los esquemas ya definidos (`PersonRequest`, `RoomRequest`, etc.) para evitar discrepancias.
+- Añadir flujos de carga masiva (CSV/Excel) y webhooks opcionales para sistemas terceros, reutilizando la lógica de servicios existente.
+
+## 3. Monitor de predicción de reservas
+- Construir una vista en el frontend que combine datos históricos (`/api/reservations/history`) y pronósticos (`/api/forecast`) para cada recurso reservado.
+- Visualizar resultados en componentes de gráficos (línea/área) que muestren demanda proyectada y ocupación real, resaltando alertas cuando se supere la capacidad disponible.
+- Exponer métricas adicionales desde el microservicio de predicción (por ejemplo, precisión, fecha de último entrenamiento) para enriquecer el tablero.
+- Automatizar la orquestación entre backend y predictor (jobs programados para `/api/forecast/train`) y notificaciones ante cambios significativos en las predicciones.
+
+## 4. Consideraciones transversales
+- Extender observabilidad (logs correlacionados, métricas) para abarcar frontend y autenticación.
+- Definir pruebas end-to-end que cubran registros, reservas y visualización del monitor para evitar regresiones.
+- Documentar flujos de usuario y diagramas actualizados en la carpeta `docs/` para alinear a los equipos de desarrollo y negocio.

--- a/java-backend/pom.xml
+++ b/java-backend/pom.xml
@@ -36,6 +36,14 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
@@ -47,6 +55,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>0.11.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.11.5</version>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/java-backend/src/main/java/com/ucaba/reservas/config/PasswordBootstrap.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/config/PasswordBootstrap.java
@@ -1,0 +1,40 @@
+package com.ucaba.reservas.config;
+
+import com.ucaba.reservas.model.Person;
+import com.ucaba.reservas.repository.PersonRepository;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Component
+public class PasswordBootstrap implements CommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(PasswordBootstrap.class);
+
+    private final PersonRepository personRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public PasswordBootstrap(PersonRepository personRepository, PasswordEncoder passwordEncoder) {
+        this.personRepository = personRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        List<Person> people = personRepository.findAll();
+        for (Person person : people) {
+            String hash = person.getPasswordHash();
+            if (StringUtils.hasText(hash) && hash.startsWith("RAW:")) {
+                String rawPassword = hash.substring(4);
+                person.setPasswordHash(passwordEncoder.encode(rawPassword));
+                log.info("Inicializando password para {}", person.getEmail());
+            }
+        }
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/config/SecurityConfig.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/config/SecurityConfig.java
@@ -1,0 +1,77 @@
+package com.ucaba.reservas.config;
+
+import com.ucaba.reservas.security.JwtAuthenticationFilter;
+import com.ucaba.reservas.security.PersonUserDetailsService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final PersonUserDetailsService userDetailsService;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter,
+                          PersonUserDetailsService userDetailsService) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/register").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/forecast/monitor").hasAnyRole("ADMIN", "STAFF", "VIEWER")
+                        .requestMatchers("/manual/**").hasRole("ADMIN")
+                        .requestMatchers("/monitor/**").hasAnyRole("ADMIN", "STAFF", "VIEWER")
+                        .requestMatchers("/api/persons/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/rooms/**", "/api/items/**").hasAnyRole("ADMIN", "STAFF")
+                        .requestMatchers(HttpMethod.PUT, "/api/rooms/**", "/api/items/**").hasAnyRole("ADMIN", "STAFF")
+                        .requestMatchers(HttpMethod.DELETE, "/api/rooms/**", "/api/items/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/reservations/**").hasAnyRole("ADMIN", "STAFF")
+                        .requestMatchers(HttpMethod.PUT, "/api/reservations/**").hasAnyRole("ADMIN", "STAFF")
+                        .requestMatchers(HttpMethod.DELETE, "/api/reservations/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/**").authenticated()
+                        .anyRequest().authenticated())
+                .authenticationProvider(authenticationProvider())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/controller/AuthController.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.ucaba.reservas.controller;
+
+import com.ucaba.reservas.dto.AuthRequest;
+import com.ucaba.reservas.dto.AuthResponse;
+import com.ucaba.reservas.dto.RegisterRequest;
+import com.ucaba.reservas.service.AuthService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    @ResponseStatus(HttpStatus.CREATED)
+    public AuthResponse register(@Valid @RequestBody RegisterRequest request) {
+        return authService.register(request);
+    }
+
+    @PostMapping("/login")
+    public AuthResponse login(@Valid @RequestBody AuthRequest request) {
+        return authService.login(request);
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/controller/ForecastController.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/controller/ForecastController.java
@@ -2,11 +2,14 @@ package com.ucaba.reservas.controller;
 
 import com.ucaba.reservas.dto.ForecastRequest;
 import com.ucaba.reservas.dto.ForecastResponse;
+import com.ucaba.reservas.dto.ForecastSnapshotResponse;
 import com.ucaba.reservas.dto.TrainRequest;
 import com.ucaba.reservas.dto.TrainResponse;
 import com.ucaba.reservas.service.ForecastService;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +35,11 @@ public class ForecastController {
     @PostMapping
     public ForecastResponse forecast(@Valid @RequestBody ForecastRequest request) {
         return forecastService.forecast(request);
+    }
+
+    @GetMapping("/monitor")
+    public List<ForecastSnapshotResponse> monitor() {
+        return forecastService.monitor();
     }
 }
 

--- a/java-backend/src/main/java/com/ucaba/reservas/controller/ForecastMonitorController.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/controller/ForecastMonitorController.java
@@ -1,0 +1,24 @@
+package com.ucaba.reservas.controller;
+
+import com.ucaba.reservas.service.ForecastService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/monitor/forecast")
+public class ForecastMonitorController {
+
+    private final ForecastService forecastService;
+
+    public ForecastMonitorController(ForecastService forecastService) {
+        this.forecastService = forecastService;
+    }
+
+    @GetMapping
+    public String view(Model model) {
+        model.addAttribute("snapshots", forecastService.monitor());
+        return "monitor/forecast";
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/controller/ManualDataController.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/controller/ManualDataController.java
@@ -1,0 +1,206 @@
+package com.ucaba.reservas.controller;
+
+import com.ucaba.reservas.dto.ItemRequest;
+import com.ucaba.reservas.dto.ReservationRequest;
+import com.ucaba.reservas.dto.RoomRequest;
+import com.ucaba.reservas.service.ItemService;
+import com.ucaba.reservas.service.PersonService;
+import com.ucaba.reservas.service.ReservationService;
+import com.ucaba.reservas.service.RoomService;
+import jakarta.validation.Valid;
+import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+@RequestMapping("/manual")
+public class ManualDataController {
+
+    private final RoomService roomService;
+    private final ItemService itemService;
+    private final ReservationService reservationService;
+    private final PersonService personService;
+
+    public ManualDataController(RoomService roomService,
+                                ItemService itemService,
+                                ReservationService reservationService,
+                                PersonService personService) {
+        this.roomService = roomService;
+        this.itemService = itemService;
+        this.reservationService = reservationService;
+        this.personService = personService;
+    }
+
+    @GetMapping
+    public String dashboard(@RequestParam(value = "tab", defaultValue = "rooms") String tab, Model model) {
+        populateModel(model);
+        ensureForms(model);
+        model.addAttribute("activeTab", tab);
+        return "manual/dashboard";
+    }
+
+    @PostMapping("/rooms")
+    public String createRoom(@Valid @ModelAttribute("roomForm") RoomRequest request,
+                             BindingResult bindingResult,
+                             RedirectAttributes redirectAttributes,
+                             Model model) {
+        if (bindingResult.hasErrors()) {
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "rooms");
+            return "manual/dashboard";
+        }
+        try {
+            roomService.create(request);
+            redirectAttributes.addFlashAttribute("successMessage", "Sala creada correctamente");
+            return "redirect:/manual?tab=rooms";
+        } catch (RuntimeException ex) {
+            bindingResult.reject("error", ex.getMessage());
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "rooms");
+            return "manual/dashboard";
+        }
+    }
+
+    @PostMapping("/rooms/{id}/update")
+    public String updateRoom(@PathVariable Long id,
+                             @RequestParam String name,
+                             @RequestParam int capacity,
+                             RedirectAttributes redirectAttributes) {
+        RoomRequest request = new RoomRequest();
+        request.setName(name);
+        request.setCapacity(capacity);
+        try {
+            roomService.update(id, request);
+            redirectAttributes.addFlashAttribute("successMessage", "Sala actualizada");
+        } catch (RuntimeException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        }
+        return "redirect:/manual?tab=rooms";
+    }
+
+    @PostMapping("/items")
+    public String createItem(@Valid @ModelAttribute("itemForm") ItemRequest request,
+                             BindingResult bindingResult,
+                             RedirectAttributes redirectAttributes,
+                             Model model) {
+        if (bindingResult.hasErrors()) {
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "items");
+            return "manual/dashboard";
+        }
+        try {
+            itemService.create(request);
+            redirectAttributes.addFlashAttribute("successMessage", "Recurso creado correctamente");
+            return "redirect:/manual?tab=items";
+        } catch (RuntimeException ex) {
+            bindingResult.reject("error", ex.getMessage());
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "items");
+            return "manual/dashboard";
+        }
+    }
+
+    @PostMapping("/items/{id}/update")
+    public String updateItem(@PathVariable Long id,
+                             @RequestParam String name,
+                             @RequestParam(defaultValue = "false") boolean available,
+                             RedirectAttributes redirectAttributes) {
+        ItemRequest request = new ItemRequest();
+        request.setName(name);
+        request.setAvailable(available);
+        try {
+            itemService.update(id, request);
+            redirectAttributes.addFlashAttribute("successMessage", "Recurso actualizado");
+        } catch (RuntimeException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        }
+        return "redirect:/manual?tab=items";
+    }
+
+    @PostMapping("/reservations")
+    public String createReservation(@Valid @ModelAttribute("reservationForm") ReservationRequest request,
+                                    BindingResult bindingResult,
+                                    RedirectAttributes redirectAttributes,
+                                    Model model) {
+        if (bindingResult.hasErrors()) {
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "reservations");
+            return "manual/dashboard";
+        }
+        try {
+            reservationService.create(request);
+            redirectAttributes.addFlashAttribute("successMessage", "Reserva registrada");
+            return "redirect:/manual?tab=reservations";
+        } catch (RuntimeException ex) {
+            bindingResult.reject("error", ex.getMessage());
+            populateModel(model);
+            ensureForms(model);
+            model.addAttribute("activeTab", "reservations");
+            return "manual/dashboard";
+        }
+    }
+
+    @PostMapping("/reservations/{id}/update")
+    public String updateReservation(@PathVariable Long id,
+                                    @RequestParam Long personId,
+                                    @RequestParam String resourceType,
+                                    @RequestParam Long resourceId,
+                                    @RequestParam("start")
+                                    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm") LocalDateTime start,
+                                    @RequestParam("end")
+                                    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm") LocalDateTime end,
+                                    RedirectAttributes redirectAttributes) {
+        ReservationRequest request = new ReservationRequest();
+        request.setPersonId(personId);
+        if ("ROOM".equalsIgnoreCase(resourceType)) {
+            request.setRoomId(resourceId);
+            request.setItemId(null);
+        } else {
+            request.setItemId(resourceId);
+            request.setRoomId(null);
+        }
+        request.setStartDateTime(start);
+        request.setEndDateTime(end);
+        try {
+            reservationService.update(id, request);
+            redirectAttributes.addFlashAttribute("successMessage", "Reserva actualizada");
+        } catch (RuntimeException ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        }
+        return "redirect:/manual?tab=reservations";
+    }
+
+    private void populateModel(Model model) {
+        model.addAttribute("rooms", roomService.findAll());
+        model.addAttribute("items", itemService.findAll());
+        model.addAttribute("reservations", reservationService.findAll());
+        model.addAttribute("people", personService.findAll());
+    }
+
+    private void ensureForms(Model model) {
+        if (!model.containsAttribute("roomForm")) {
+            model.addAttribute("roomForm", new RoomRequest());
+        }
+        if (!model.containsAttribute("itemForm")) {
+            model.addAttribute("itemForm", new ItemRequest());
+        }
+        if (!model.containsAttribute("reservationForm")) {
+            ReservationRequest form = new ReservationRequest();
+            model.addAttribute("reservationForm", form);
+        }
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/AuthRequest.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/AuthRequest.java
@@ -1,0 +1,33 @@
+package com.ucaba.reservas.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public class AuthRequest {
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public AuthRequest() {
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/AuthResponse.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/AuthResponse.java
@@ -1,0 +1,38 @@
+package com.ucaba.reservas.dto;
+
+public class AuthResponse {
+
+    private final String token;
+    private final long expiresIn;
+    private final String fullName;
+    private final String email;
+    private final String role;
+
+    public AuthResponse(String token, long expiresIn, String fullName, String email, String role) {
+        this.token = token;
+        this.expiresIn = expiresIn;
+        this.fullName = fullName;
+        this.email = email;
+        this.role = role;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public long getExpiresIn() {
+        return expiresIn;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/ForecastPoint.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/ForecastPoint.java
@@ -1,5 +1,7 @@
 package com.ucaba.reservas.dto;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDate;
 
 public class ForecastPoint {
@@ -9,7 +11,11 @@ public class ForecastPoint {
     private final Double yhatLower;
     private final Double yhatUpper;
 
-    public ForecastPoint(LocalDate date, double yhat, Double yhatLower, Double yhatUpper) {
+    @JsonCreator
+    public ForecastPoint(@JsonProperty("date") LocalDate date,
+                         @JsonProperty("yhat") double yhat,
+                         @JsonProperty("yhatLower") Double yhatLower,
+                         @JsonProperty("yhatUpper") Double yhatUpper) {
         this.date = date;
         this.yhat = yhat;
         this.yhatLower = yhatLower;

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/ForecastSnapshotResponse.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/ForecastSnapshotResponse.java
@@ -1,0 +1,67 @@
+package com.ucaba.reservas.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+public class ForecastSnapshotResponse {
+
+    private final Long id;
+    private final String seriesId;
+    private final String resourceType;
+    private final Long resourceId;
+    private final LocalDateTime generatedAt;
+    private final int horizonDays;
+    private final Map<String, Double> metrics;
+    private final List<ForecastPoint> points;
+
+    public ForecastSnapshotResponse(Long id,
+                                    String seriesId,
+                                    String resourceType,
+                                    Long resourceId,
+                                    LocalDateTime generatedAt,
+                                    int horizonDays,
+                                    Map<String, Double> metrics,
+                                    List<ForecastPoint> points) {
+        this.id = id;
+        this.seriesId = seriesId;
+        this.resourceType = resourceType;
+        this.resourceId = resourceId;
+        this.generatedAt = generatedAt;
+        this.horizonDays = horizonDays;
+        this.metrics = Map.copyOf(metrics);
+        this.points = List.copyOf(points);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSeriesId() {
+        return seriesId;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public LocalDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public int getHorizonDays() {
+        return horizonDays;
+    }
+
+    public Map<String, Double> getMetrics() {
+        return metrics;
+    }
+
+    public List<ForecastPoint> getPoints() {
+        return points;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/RegisterRequest.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/RegisterRequest.java
@@ -2,10 +2,9 @@ package com.ucaba.reservas.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public class PersonRequest {
+public class RegisterRequest {
 
     @NotBlank
     private String fullName;
@@ -14,13 +13,14 @@ public class PersonRequest {
     @Email
     private String email;
 
-    @NotNull
-    private String role;
-
+    @NotBlank
     @Size(min = 8, message = "La contraseña debe tener al menos 8 caracteres")
     private String password;
 
-    public PersonRequest() {
+    @NotBlank
+    private String role;
+
+    public RegisterRequest() {
     }
 
     public String getFullName() {
@@ -39,19 +39,19 @@ public class PersonRequest {
         this.email = email;
     }
 
-    public String getRole() {
-        return role;
-    }
-
-    public void setRole(String role) {
-        this.role = role;
-    }
-
     public String getPassword() {
         return password;
     }
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
     }
 }

--- a/java-backend/src/main/java/com/ucaba/reservas/dto/ReservationRequest.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/dto/ReservationRequest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import org.springframework.format.annotation.DateTimeFormat;
 
 public class ReservationRequest {
 
@@ -16,11 +17,13 @@ public class ReservationRequest {
 
     @NotNull
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime startDateTime;
 
     @NotNull
     @Future
     @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     private LocalDateTime endDateTime;
 
     public ReservationRequest() {

--- a/java-backend/src/main/java/com/ucaba/reservas/mapper/PersonMapper.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/mapper/PersonMapper.java
@@ -4,7 +4,9 @@ import com.ucaba.reservas.dto.PersonRequest;
 import com.ucaba.reservas.dto.PersonResponse;
 import com.ucaba.reservas.model.Person;
 import com.ucaba.reservas.model.UserRole;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class PersonMapper {
@@ -12,11 +14,20 @@ public class PersonMapper {
     /**
      * Mapper centralizes enum parsing so controllers remain slim.
      */
+    private final PasswordEncoder passwordEncoder;
+
+    public PersonMapper(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
     public Person toEntity(PersonRequest request) {
         Person person = new Person();
         person.setFullName(request.getFullName());
         person.setEmail(request.getEmail());
         person.setRole(UserRole.valueOf(request.getRole().toUpperCase()));
+        if (StringUtils.hasText(request.getPassword())) {
+            person.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        }
         return person;
     }
 
@@ -24,6 +35,9 @@ public class PersonMapper {
         person.setFullName(request.getFullName());
         person.setEmail(request.getEmail());
         person.setRole(UserRole.valueOf(request.getRole().toUpperCase()));
+        if (StringUtils.hasText(request.getPassword())) {
+            person.setPasswordHash(passwordEncoder.encode(request.getPassword()));
+        }
     }
 
     public PersonResponse toResponse(Person person) {

--- a/java-backend/src/main/java/com/ucaba/reservas/model/ForecastSnapshot.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/model/ForecastSnapshot.java
@@ -1,0 +1,109 @@
+package com.ucaba.reservas.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "forecast_snapshots")
+public class ForecastSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String seriesId;
+
+    @Column(nullable = false)
+    private String resourceType;
+
+    @Column(nullable = false)
+    private Long resourceId;
+
+    @Column(nullable = false)
+    private LocalDateTime generatedAt;
+
+    @Column(nullable = false)
+    private int horizonDays;
+
+    @Lob
+    @Column(nullable = false)
+    private String metricsJson;
+
+    @Lob
+    @Column(nullable = false)
+    private String pointsJson;
+
+    public ForecastSnapshot() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getSeriesId() {
+        return seriesId;
+    }
+
+    public void setSeriesId(String seriesId) {
+        this.seriesId = seriesId;
+    }
+
+    public String getResourceType() {
+        return resourceType;
+    }
+
+    public void setResourceType(String resourceType) {
+        this.resourceType = resourceType;
+    }
+
+    public Long getResourceId() {
+        return resourceId;
+    }
+
+    public void setResourceId(Long resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    public LocalDateTime getGeneratedAt() {
+        return generatedAt;
+    }
+
+    public void setGeneratedAt(LocalDateTime generatedAt) {
+        this.generatedAt = generatedAt;
+    }
+
+    public int getHorizonDays() {
+        return horizonDays;
+    }
+
+    public void setHorizonDays(int horizonDays) {
+        this.horizonDays = horizonDays;
+    }
+
+    public String getMetricsJson() {
+        return metricsJson;
+    }
+
+    public void setMetricsJson(String metricsJson) {
+        this.metricsJson = metricsJson;
+    }
+
+    public String getPointsJson() {
+        return pointsJson;
+    }
+
+    public void setPointsJson(String pointsJson) {
+        this.pointsJson = pointsJson;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/model/Person.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/model/Person.java
@@ -23,6 +23,9 @@ public class Person {
     @Column(nullable = false, unique = true)
     private String email;
 
+    @Column(nullable = false, name = "password_hash")
+    private String passwordHash;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private UserRole role = UserRole.STAFF;
@@ -53,6 +56,14 @@ public class Person {
 
     public void setEmail(String email) {
         this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
     }
 
     public UserRole getRole() {

--- a/java-backend/src/main/java/com/ucaba/reservas/repository/ForecastSnapshotRepository.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/repository/ForecastSnapshotRepository.java
@@ -1,0 +1,9 @@
+package com.ucaba.reservas.repository;
+
+import com.ucaba.reservas.model.ForecastSnapshot;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ForecastSnapshotRepository extends JpaRepository<ForecastSnapshot, Long> {
+    List<ForecastSnapshot> findTop20ByOrderByGeneratedAtDesc();
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/security/JwtAuthenticationFilter.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/security/JwtAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.ucaba.reservas.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+    private final PersonUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider,
+                                   PersonUserDetailsService userDetailsService) {
+        this.tokenProvider = tokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring(7);
+            if (tokenProvider.validateToken(token)) {
+                String username = tokenProvider.getUsername(token);
+                if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                    UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+                    UsernamePasswordAuthenticationToken authentication =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/security/JwtTokenProvider.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/security/JwtTokenProvider.java
@@ -1,0 +1,68 @@
+package com.ucaba.reservas.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey secretKey;
+    private final long expirationMinutes;
+
+    public JwtTokenProvider(@Value("${security.jwt.secret}") String secret,
+                            @Value("${security.jwt.expiration-minutes:60}") long expirationMinutes) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirationMinutes = expirationMinutes;
+    }
+
+    public String generateToken(UserDetails userDetails) {
+        Instant now = Instant.now();
+        Instant expiration = now.plus(expirationMinutes, ChronoUnit.MINUTES);
+        List<String> roles = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(Date.from(now))
+                .setExpiration(Date.from(expiration))
+                .claim("roles", roles)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (Exception ex) {
+            return false;
+        }
+    }
+
+    public String getUsername(String token) {
+        return getClaims(token).getBody().getSubject();
+    }
+
+    public long getExpirationMinutes() {
+        return expirationMinutes;
+    }
+
+    private Jws<Claims> getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/security/PersonUserDetailsService.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/security/PersonUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.ucaba.reservas.security;
+
+import com.ucaba.reservas.model.Person;
+import com.ucaba.reservas.repository.PersonRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PersonUserDetailsService implements UserDetailsService {
+
+    private final PersonRepository personRepository;
+
+    public PersonUserDetailsService(PersonRepository personRepository) {
+        this.personRepository = personRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Person person = personRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("Usuario no encontrado"));
+        return new UserPrincipal(person);
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/security/UserPrincipal.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/security/UserPrincipal.java
@@ -1,0 +1,68 @@
+package com.ucaba.reservas.security;
+
+import com.ucaba.reservas.model.Person;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class UserPrincipal implements UserDetails {
+
+    private final Long id;
+    private final String email;
+    private final String fullName;
+    private final String passwordHash;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public UserPrincipal(Person person) {
+        this.id = person.getId();
+        this.email = person.getEmail();
+        this.fullName = person.getFullName();
+        this.passwordHash = person.getPasswordHash();
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + person.getRole().name()));
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return passwordHash;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/service/AuthService.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/service/AuthService.java
@@ -1,0 +1,11 @@
+package com.ucaba.reservas.service;
+
+import com.ucaba.reservas.dto.AuthRequest;
+import com.ucaba.reservas.dto.AuthResponse;
+import com.ucaba.reservas.dto.RegisterRequest;
+
+public interface AuthService {
+    AuthResponse register(RegisterRequest request);
+
+    AuthResponse login(AuthRequest request);
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/service/ForecastService.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/service/ForecastService.java
@@ -2,12 +2,16 @@ package com.ucaba.reservas.service;
 
 import com.ucaba.reservas.dto.ForecastRequest;
 import com.ucaba.reservas.dto.ForecastResponse;
+import com.ucaba.reservas.dto.ForecastSnapshotResponse;
 import com.ucaba.reservas.dto.TrainRequest;
 import com.ucaba.reservas.dto.TrainResponse;
+import java.util.List;
 
 public interface ForecastService {
     TrainResponse train(TrainRequest request);
 
     ForecastResponse forecast(ForecastRequest request);
+
+    List<ForecastSnapshotResponse> monitor();
 }
 

--- a/java-backend/src/main/java/com/ucaba/reservas/service/impl/AuthServiceImpl.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/service/impl/AuthServiceImpl.java
@@ -1,0 +1,76 @@
+package com.ucaba.reservas.service.impl;
+
+import com.ucaba.reservas.dto.AuthRequest;
+import com.ucaba.reservas.dto.AuthResponse;
+import com.ucaba.reservas.dto.RegisterRequest;
+import com.ucaba.reservas.exception.BadRequestException;
+import com.ucaba.reservas.exception.ConflictException;
+import com.ucaba.reservas.mapper.PersonMapper;
+import com.ucaba.reservas.model.Person;
+import com.ucaba.reservas.repository.PersonRepository;
+import com.ucaba.reservas.security.JwtTokenProvider;
+import com.ucaba.reservas.security.UserPrincipal;
+import com.ucaba.reservas.service.AuthService;
+import java.time.Duration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AuthServiceImpl implements AuthService {
+
+    private final PersonRepository personRepository;
+    private final PersonMapper personMapper;
+    private final JwtTokenProvider tokenProvider;
+    private final AuthenticationManager authenticationManager;
+
+    public AuthServiceImpl(PersonRepository personRepository,
+                           PersonMapper personMapper,
+                           JwtTokenProvider tokenProvider,
+                           AuthenticationManager authenticationManager) {
+        this.personRepository = personRepository;
+        this.personMapper = personMapper;
+        this.tokenProvider = tokenProvider;
+        this.authenticationManager = authenticationManager;
+    }
+
+    @Override
+    public AuthResponse register(RegisterRequest request) {
+        personRepository.findByEmail(request.getEmail()).ifPresent(existing -> {
+            throw new ConflictException("Email ya registrado");
+        });
+        try {
+            Person person = personMapper.toEntity(toPersonRequest(request));
+            Person saved = personRepository.save(person);
+            UserPrincipal principal = new UserPrincipal(saved);
+            String token = tokenProvider.generateToken(principal);
+            long expiresIn = Duration.ofMinutes(tokenProvider.getExpirationMinutes()).toSeconds();
+            return new AuthResponse(token, expiresIn, saved.getFullName(), saved.getEmail(), saved.getRole().name());
+        } catch (IllegalArgumentException ex) {
+            throw new BadRequestException("Rol invalido");
+        }
+    }
+
+    @Override
+    public AuthResponse login(AuthRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        String token = tokenProvider.generateToken(principal);
+        long expiresIn = Duration.ofMinutes(tokenProvider.getExpirationMinutes()).toSeconds();
+        String role = principal.getAuthorities().iterator().next().getAuthority().replace("ROLE_", "");
+        return new AuthResponse(token, expiresIn, principal.getFullName(), principal.getUsername(), role);
+    }
+
+    private com.ucaba.reservas.dto.PersonRequest toPersonRequest(RegisterRequest request) {
+        com.ucaba.reservas.dto.PersonRequest personRequest = new com.ucaba.reservas.dto.PersonRequest();
+        personRequest.setFullName(request.getFullName());
+        personRequest.setEmail(request.getEmail());
+        personRequest.setRole(request.getRole());
+        personRequest.setPassword(request.getPassword());
+        return personRequest;
+    }
+}

--- a/java-backend/src/main/java/com/ucaba/reservas/service/impl/ForecastServiceImpl.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/service/impl/ForecastServiceImpl.java
@@ -2,17 +2,24 @@ package com.ucaba.reservas.service.impl;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ucaba.reservas.dto.ForecastPoint;
 import com.ucaba.reservas.dto.ForecastRequest;
 import com.ucaba.reservas.dto.ForecastResponse;
 import com.ucaba.reservas.dto.HistoryPoint;
 import com.ucaba.reservas.dto.HistoryResponse;
+import com.ucaba.reservas.dto.ForecastSnapshotResponse;
 import com.ucaba.reservas.dto.TrainRequest;
 import com.ucaba.reservas.dto.TrainResponse;
 import com.ucaba.reservas.exception.BadRequestException;
 import com.ucaba.reservas.service.ForecastService;
 import com.ucaba.reservas.service.ReservationService;
+import com.ucaba.reservas.model.ForecastSnapshot;
+import com.ucaba.reservas.repository.ForecastSnapshotRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -32,18 +39,24 @@ public class ForecastServiceImpl implements ForecastService {
     private static final Logger log = LoggerFactory.getLogger(ForecastServiceImpl.class);
 
     private final ReservationService reservationService;
+    private final ForecastSnapshotRepository snapshotRepository;
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
     private final String baseUrl;
     private final int defaultHorizon;
     private final int maxHorizon;
 
     public ForecastServiceImpl(ReservationService reservationService,
+                               ForecastSnapshotRepository snapshotRepository,
                                RestTemplate restTemplate,
+                               ObjectMapper objectMapper,
                                @Value("${predictor.base-url}") String baseUrl,
                                @Value("${reservas.forecast.default-horizon-days}") int defaultHorizon,
                                @Value("${reservas.forecast.max-horizon-days}") int maxHorizon) {
         this.reservationService = reservationService;
+        this.snapshotRepository = snapshotRepository;
         this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
         this.baseUrl = baseUrl;
         this.defaultHorizon = defaultHorizon;
         this.maxHorizon = maxHorizon;
@@ -88,17 +101,73 @@ public class ForecastServiceImpl implements ForecastService {
             List<ForecastPoint> points = result.predictions().stream()
                     .map(p -> new ForecastPoint(p.date(), p.yhat(), p.yhatLower(), p.yhatUpper()))
                     .collect(Collectors.toList());
-            return new ForecastResponse(result.seriesId(), result.metrics(), points);
+            ForecastResponse response = new ForecastResponse(result.seriesId(), result.metrics(), points);
+            persistSnapshot(request, response);
+            return response;
         } catch (RestClientException ex) {
             log.error("Error llamando al predictor", ex);
             throw new BadRequestException("No se pudo obtener el pronostico");
         }
     }
 
+    @Override
+    public List<ForecastSnapshotResponse> monitor() {
+        return snapshotRepository.findTop20ByOrderByGeneratedAtDesc().stream()
+                .map(this::toSnapshotResponse)
+                .collect(Collectors.toList());
+    }
+
     private <T> HttpEntity<T> buildEntity(T payload) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         return new HttpEntity<>(payload, headers);
+    }
+
+    private void persistSnapshot(ForecastRequest request, ForecastResponse response) {
+        ForecastSnapshot snapshot = new ForecastSnapshot();
+        snapshot.setSeriesId(response.getSeriesId());
+        snapshot.setResourceType(request.getResourceType());
+        snapshot.setResourceId(request.getResourceId());
+        snapshot.setGeneratedAt(LocalDateTime.now());
+        snapshot.setHorizonDays(response.getPoints().size());
+        snapshot.setMetricsJson(writeJson(response.getMetrics()));
+        snapshot.setPointsJson(writeJson(response.getPoints()));
+        snapshotRepository.save(snapshot);
+    }
+
+    private ForecastSnapshotResponse toSnapshotResponse(ForecastSnapshot snapshot) {
+        Map<String, Double> metrics = readMetrics(snapshot.getMetricsJson());
+        List<ForecastPoint> points = readPoints(snapshot.getPointsJson());
+        return new ForecastSnapshotResponse(snapshot.getId(), snapshot.getSeriesId(), snapshot.getResourceType(),
+                snapshot.getResourceId(), snapshot.getGeneratedAt(), snapshot.getHorizonDays(), metrics, points);
+    }
+
+    private String writeJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new BadRequestException("No se pudo serializar el resultado del pronostico");
+        }
+    }
+
+    private Map<String, Double> readMetrics(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Double>>() {
+            });
+        } catch (JsonProcessingException ex) {
+            log.error("No se pudo parsear métricas de pronostico", ex);
+            throw new BadRequestException("Error interno leyendo el monitoreo");
+        }
+    }
+
+    private List<ForecastPoint> readPoints(String json) {
+        try {
+            return objectMapper.readValue(json, new TypeReference<List<ForecastPoint>>() {
+            });
+        } catch (JsonProcessingException ex) {
+            log.error("No se pudo parsear puntos de pronostico", ex);
+            throw new BadRequestException("Error interno leyendo el monitoreo");
+        }
     }
 
     private record TrainPayload(@JsonProperty("series_id") String seriesId,

--- a/java-backend/src/main/java/com/ucaba/reservas/service/impl/PersonServiceImpl.java
+++ b/java-backend/src/main/java/com/ucaba/reservas/service/impl/PersonServiceImpl.java
@@ -2,6 +2,7 @@ package com.ucaba.reservas.service.impl;
 
 import com.ucaba.reservas.dto.PersonRequest;
 import com.ucaba.reservas.dto.PersonResponse;
+import com.ucaba.reservas.exception.BadRequestException;
 import com.ucaba.reservas.exception.ConflictException;
 import com.ucaba.reservas.exception.NotFoundException;
 import com.ucaba.reservas.mapper.PersonMapper;
@@ -13,6 +14,7 @@ import java.util.stream.Collectors;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @Transactional
@@ -47,6 +49,9 @@ public class PersonServiceImpl implements PersonService {
         repository.findByEmail(request.getEmail()).ifPresent(existing -> {
             throw new ConflictException("Email ya registrado");
         });
+        if (!StringUtils.hasText(request.getPassword())) {
+            throw new BadRequestException("La contraseña es obligatoria");
+        }
         try {
             Person person = mapper.toEntity(request);
             return mapper.toResponse(repository.save(person));
@@ -61,6 +66,9 @@ public class PersonServiceImpl implements PersonService {
     public PersonResponse update(Long id, PersonRequest request) {
         Person person = repository.findById(id)
                 .orElseThrow(() -> new NotFoundException("Persona no encontrada"));
+        if (StringUtils.hasText(request.getPassword()) && request.getPassword().length() < 8) {
+            throw new BadRequestException("La contraseña debe tener al menos 8 caracteres");
+        }
         try {
             mapper.update(person, request);
             return mapper.toResponse(repository.save(person));

--- a/java-backend/src/main/resources/application.yml
+++ b/java-backend/src/main/resources/application.yml
@@ -30,3 +30,7 @@ reservas:
   forecast:
     default-horizon-days: 14
     max-horizon-days: 60
+security:
+  jwt:
+    secret: VerySecretKeyForJwtDemo2025!1234567890
+    expiration-minutes: 120

--- a/java-backend/src/main/resources/data.sql
+++ b/java-backend/src/main/resources/data.sql
@@ -7,6 +7,7 @@ CREATE TABLE persons (
     id BIGINT PRIMARY KEY AUTO_INCREMENT,
     full_name VARCHAR(255) NOT NULL,
     email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
     role VARCHAR(32) NOT NULL
 );
 
@@ -34,10 +35,21 @@ CREATE TABLE reservations (
     CONSTRAINT fk_reservation_room FOREIGN KEY (room_id) REFERENCES rooms(id)
 );
 
-INSERT INTO persons (id, full_name, email, role) VALUES
-  (1, 'Ana Perez', 'ana.perez@organizacion.com', 'STAFF'),
-  (2, 'Juan Gomez', 'juan.gomez@organizacion.com', 'STAFF'),
-  (3, 'Maria Lopez', 'maria.lopez@organizacion.com', 'ADMIN');
+CREATE TABLE forecast_snapshots (
+    id BIGINT PRIMARY KEY AUTO_INCREMENT,
+    series_id VARCHAR(255) NOT NULL,
+    resource_type VARCHAR(64) NOT NULL,
+    resource_id BIGINT NOT NULL,
+    generated_at TIMESTAMP NOT NULL,
+    horizon_days INT NOT NULL,
+    metrics_json CLOB NOT NULL,
+    points_json CLOB NOT NULL
+);
+
+INSERT INTO persons (id, full_name, email, password_hash, role) VALUES
+  (1, 'Ana Perez', 'ana.perez@organizacion.com', 'RAW:AnaSecure1!', 'STAFF'),
+  (2, 'Juan Gomez', 'juan.gomez@organizacion.com', 'RAW:JuanSecure1!', 'STAFF'),
+  (3, 'Maria Lopez', 'maria.lopez@organizacion.com', 'RAW:AdminSecure1!', 'ADMIN');
 ALTER TABLE persons ALTER COLUMN id RESTART WITH 4;
 
 INSERT INTO items (id, name, available) VALUES
@@ -57,3 +69,5 @@ INSERT INTO reservations (id, item_id, room_id, person_id, start_date_time, end_
   (2, NULL, 2, 2, '2025-09-12T14:00:00', '2025-09-12T16:00:00'),
   (3, 2, NULL, 3, '2025-09-13T09:00:00', '2025-09-13T10:00:00');
 ALTER TABLE reservations ALTER COLUMN id RESTART WITH 4;
+
+ALTER TABLE forecast_snapshots ALTER COLUMN id RESTART WITH 1;

--- a/java-backend/src/main/resources/templates/manual/dashboard.html
+++ b/java-backend/src/main/resources/templates/manual/dashboard.html
@@ -1,0 +1,235 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Gestión manual de reservas</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f4f6f8; }
+        header { background: #1f3c88; color: #fff; padding: 1rem 2rem; }
+        main { padding: 2rem; }
+        h1 { margin: 0; font-size: 1.6rem; }
+        .tabs { display: flex; gap: 1rem; margin-bottom: 1.5rem; }
+        .tabs a { text-decoration: none; padding: 0.5rem 1rem; border-radius: 4px; color: #1f3c88; background: #e0e7ff; font-weight: bold; }
+        .tabs a.active { background: #1f3c88; color: #fff; }
+        .card { background: #fff; border-radius: 8px; padding: 1.5rem; box-shadow: 0 1px 4px rgba(0,0,0,0.1); margin-bottom: 2rem; }
+        label { display: block; margin-top: 0.8rem; font-weight: bold; }
+        input, select { width: 100%; padding: 0.5rem; margin-top: 0.3rem; border: 1px solid #ccc; border-radius: 4px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+        th, td { padding: 0.75rem; border-bottom: 1px solid #e5e7eb; text-align: left; }
+        th { background: #f8fafc; }
+        .actions { display: flex; gap: 0.5rem; }
+        button { padding: 0.5rem 1rem; border: none; border-radius: 4px; background: #1f3c88; color: #fff; cursor: pointer; }
+        button.secondary { background: #64748b; }
+        .alert { padding: 0.75rem 1rem; border-radius: 4px; margin-bottom: 1rem; }
+        .alert.success { background: #ecfdf5; color: #047857; }
+        .alert.error { background: #fef2f2; color: #b91c1c; }
+        .grid { display: grid; gap: 1rem; }
+        .grid.two { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
+        .inline-form { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+        .inline-form input { width: auto; min-width: 120px; }
+        .inline-form button { margin-top: 0; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Gestión manual de recursos y reservas</h1>
+</header>
+<main>
+    <div th:if="${successMessage}" class="alert success" th:text="${successMessage}"></div>
+    <div th:if="${errorMessage}" class="alert error" th:text="${errorMessage}"></div>
+    <div th:if="${#fields.hasErrors('*')}" class="alert error">Revisá los datos del formulario.</div>
+    <nav class="tabs">
+        <a th:href="@{/manual(tab='rooms')}" th:classappend="${activeTab}=='rooms' ? 'active'" >Salas</a>
+        <a th:href="@{/manual(tab='items')}" th:classappend="${activeTab}=='items' ? 'active'" >Recursos móviles</a>
+        <a th:href="@{/manual(tab='reservations')}" th:classappend="${activeTab}=='reservations' ? 'active'" >Reservas</a>
+    </nav>
+
+    <section th:if="${activeTab}=='rooms'">
+        <div class="card">
+            <h2>Nueva sala</h2>
+            <form th:action="@{/manual/rooms}" method="post" th:object="${roomForm}">
+                <label for="roomName">Nombre</label>
+                <input id="roomName" type="text" th:field="*{name}" placeholder="Ej: Sala Norte" required>
+                <div th:if="${#fields.hasErrors('name')}" class="alert error" th:errors="*{name}"></div>
+
+                <label for="roomCapacity">Capacidad</label>
+                <input id="roomCapacity" type="number" min="1" th:field="*{capacity}" placeholder="Ej: 10" required>
+                <div th:if="${#fields.hasErrors('capacity')}" class="alert error" th:errors="*{capacity}"></div>
+
+                <button type="submit">Guardar sala</button>
+            </form>
+        </div>
+
+        <div class="card">
+            <h2>Salas existentes</h2>
+            <table>
+                <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Capacidad</th>
+                    <th>Acciones</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="room : ${rooms}">
+                    <td th:text="${room.name}"></td>
+                    <td th:text="${room.capacity}"></td>
+                    <td>
+                        <form class="inline-form" th:action="@{/manual/rooms/{id}/update(id=${room.id})}" method="post">
+                            <input type="text" name="name" th:value="${room.name}" required>
+                            <input type="number" name="capacity" min="1" th:value="${room.capacity}" required>
+                            <button type="submit" class="secondary">Actualizar</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section th:if="${activeTab}=='items'">
+        <div class="card">
+            <h2>Nuevo recurso móvil</h2>
+            <form th:action="@{/manual/items}" method="post" th:object="${itemForm}">
+                <label for="itemName">Nombre</label>
+                <input id="itemName" type="text" th:field="*{name}" placeholder="Ej: Proyector Epson" required>
+                <div th:if="${#fields.hasErrors('name')}" class="alert error" th:errors="*{name}"></div>
+
+                <label>Disponible</label>
+                <select th:field="*{available}">
+                    <option th:value="true">Sí</option>
+                    <option th:value="false">No</option>
+                </select>
+
+                <button type="submit">Guardar recurso</button>
+            </form>
+        </div>
+
+        <div class="card">
+            <h2>Recursos disponibles</h2>
+            <table>
+                <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Disponible</th>
+                    <th>Acciones</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="item : ${items}">
+                    <td th:text="${item.name}"></td>
+                    <td th:text="${item.available} ? 'Sí' : 'No'"></td>
+                    <td>
+                        <form class="inline-form" th:action="@{/manual/items/{id}/update(id=${item.id})}" method="post">
+                            <input type="text" name="name" th:value="${item.name}" required>
+                            <select name="available">
+                                <option th:value="true" th:selected="${item.available}">Sí</option>
+                                <option th:value="false" th:selected="${!item.available}">No</option>
+                            </select>
+                            <button type="submit" class="secondary">Actualizar</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <section th:if="${activeTab}=='reservations'">
+        <div class="card">
+            <h2>Nueva reserva</h2>
+            <div class="grid two">
+                <form th:action="@{/manual/reservations}" method="post" th:object="${reservationForm}">
+                    <h3>Reserva de sala</h3>
+                    <input type="hidden" th:field="*{itemId}" value="">
+                    <label>Solicitante</label>
+                    <select th:field="*{personId}" required>
+                        <option value="" disabled selected>Seleccioná una persona</option>
+                        <option th:each="person : ${people}" th:value="${person.id}" th:text="${person.fullName}"></option>
+                    </select>
+                    <div th:if="${#fields.hasErrors('personId')}" class="alert error" th:errors="*{personId}"></div>
+
+                    <label>Sala</label>
+                    <select th:field="*{roomId}" required>
+                        <option value="" disabled selected>Seleccioná sala</option>
+                        <option th:each="room : ${rooms}" th:value="${room.id}" th:text="${room.name}"></option>
+                    </select>
+
+                    <label>Inicio</label>
+                    <input type="datetime-local" th:field="*{startDateTime}" required>
+                    <div th:if="${#fields.hasErrors('startDateTime')}" class="alert error" th:errors="*{startDateTime}"></div>
+
+                    <label>Fin</label>
+                    <input type="datetime-local" th:field="*{endDateTime}" required>
+                    <div th:if="${#fields.hasErrors('endDateTime')}" class="alert error" th:errors="*{endDateTime}"></div>
+
+                    <button type="submit">Reservar sala</button>
+                </form>
+
+                <form th:action="@{/manual/reservations}" method="post">
+                    <h3>Reserva de recurso móvil</h3>
+                    <input type="hidden" name="roomId" value="">
+                    <label>Solicitante</label>
+                    <select name="personId" required>
+                        <option value="" disabled selected>Seleccioná una persona</option>
+                        <option th:each="person : ${people}" th:value="${person.id}" th:text="${person.fullName}"></option>
+                    </select>
+
+                    <label>Recurso</label>
+                    <select name="itemId" required>
+                        <option value="" disabled selected>Seleccioná recurso</option>
+                        <option th:each="item : ${items}" th:value="${item.id}" th:text="${item.name}"></option>
+                    </select>
+
+                    <label>Inicio</label>
+                    <input type="datetime-local" name="startDateTime" required>
+
+                    <label>Fin</label>
+                    <input type="datetime-local" name="endDateTime" required>
+
+                    <button type="submit">Reservar recurso</button>
+                </form>
+            </div>
+        </div>
+
+        <div class="card">
+            <h2>Reservas activas</h2>
+            <table>
+                <thead>
+                <tr>
+                    <th>Recurso</th>
+                    <th>Solicitante</th>
+                    <th>Inicio</th>
+                    <th>Fin</th>
+                    <th>Acciones</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="reservation : ${reservations}">
+                    <td>
+                        <span th:text="${reservation.resourceName}"></span>
+                        <small th:text="${reservation.resourceType}"></small>
+                    </td>
+                    <td th:text="${reservation.personName}"></td>
+                    <td th:text="${#temporals.format(reservation.startDateTime, 'dd/MM/yyyy HH:mm')}"></td>
+                    <td th:text="${#temporals.format(reservation.endDateTime, 'dd/MM/yyyy HH:mm')}"></td>
+                    <td>
+                        <form class="inline-form" th:action="@{/manual/reservations/{id}/update(id=${reservation.id})}" method="post">
+                            <input type="hidden" name="personId" th:value="${reservation.personId}">
+                            <input type="hidden" name="resourceType" th:value="${reservation.resourceType}">
+                            <input type="hidden" name="resourceId" th:value="${reservation.resourceId}">
+                            <label>Inicio</label>
+                            <input type="datetime-local" name="start" th:value="${#temporals.format(reservation.startDateTime, 'yyyy-MM-dd\'T\'HH:mm')}" required>
+                            <label>Fin</label>
+                            <input type="datetime-local" name="end" th:value="${#temporals.format(reservation.endDateTime, 'yyyy-MM-dd\'T\'HH:mm')}" required>
+                            <button type="submit" class="secondary">Actualizar</button>
+                        </form>
+                    </td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+</main>
+</body>
+</html>

--- a/java-backend/src/main/resources/templates/monitor/forecast.html
+++ b/java-backend/src/main/resources/templates/monitor/forecast.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Monitor de predicción</title>
+    <style>
+        body { font-family: 'Segoe UI', Tahoma, sans-serif; margin: 0; padding: 0; background: #0f172a; color: #e2e8f0; }
+        header { padding: 1.5rem 2rem; background: #1e293b; display: flex; justify-content: space-between; align-items: center; }
+        a { color: #38bdf8; text-decoration: none; }
+        main { padding: 2rem; }
+        .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.5rem; }
+        .card { background: rgba(30, 41, 59, 0.85); border-radius: 12px; padding: 1.5rem; box-shadow: 0 10px 25px rgba(15, 23, 42, 0.6); }
+        .card h2 { margin-top: 0; font-size: 1.2rem; color: #f8fafc; }
+        .meta { display: flex; justify-content: space-between; font-size: 0.9rem; margin-bottom: 1rem; color: #cbd5f5; }
+        .metrics { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 1rem; }
+        .badge { background: rgba(56, 189, 248, 0.15); padding: 0.4rem 0.75rem; border-radius: 999px; font-size: 0.85rem; }
+        table { width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.85rem; }
+        th, td { padding: 0.4rem 0.3rem; border-bottom: 1px solid rgba(148, 163, 184, 0.2); text-align: left; }
+        th { color: #cbd5f5; font-weight: 600; }
+        .empty { text-align: center; padding: 2rem; border: 2px dashed rgba(148, 163, 184, 0.3); border-radius: 12px; }
+    </style>
+</head>
+<body>
+<header>
+    <h1>Monitor de predicción de reservas</h1>
+    <a href="/manual">Volver a gestión manual</a>
+</header>
+<main>
+    <div th:if="${#lists.isEmpty(snapshots)}" class="empty">
+        Aún no se generaron pronósticos. Ejecutá una predicción desde la API para poblar el monitor.
+    </div>
+    <div class="grid" th:if="${!#lists.isEmpty(snapshots)}">
+        <article class="card" th:each="snapshot : ${snapshots}">
+            <h2 th:text="${snapshot.seriesId}"></h2>
+            <div class="meta">
+                <span th:text="'Recurso: ' + ${snapshot.resourceType} + ' #' + ${snapshot.resourceId}"></span>
+                <span th:text="${#temporals.format(snapshot.generatedAt, 'dd/MM/yyyy HH:mm')}"></span>
+            </div>
+            <div class="metrics">
+                <span class="badge" th:each="entry : ${snapshot.metrics.entrySet()}"
+                      th:text="${entry.key} + ': ' + ${#numbers.formatDecimal(entry.value, 1, 3)}"></span>
+            </div>
+            <table>
+                <thead>
+                <tr>
+                    <th>Fecha</th>
+                    <th>Pronóstico</th>
+                    <th>Min</th>
+                    <th>Max</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="point : ${snapshot.points}">
+                    <td th:text="${point.date}"></td>
+                    <td th:text="${#numbers.formatDecimal(point.yhat, 1, 1)}"></td>
+                    <td th:text="${point.yhatLower != null ? #numbers.formatDecimal(point.yhatLower, 1, 1) : '-'}"></td>
+                    <td th:text="${point.yhatUpper != null ? #numbers.formatDecimal(point.yhatUpper, 1, 1) : '-'}"></td>
+                </tr>
+                </tbody>
+            </table>
+        </article>
+    </div>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add JWT-secured authentication endpoints and role-based access configuration
- provide a manual management console for rooms, items, and reservations
- persist forecast snapshots and expose API/UI to monitor prediction metrics

## Testing
- mvn test *(fails: cannot download dependencies from Maven Central - 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e3bf6af03c8330a83674079ad0c02c